### PR TITLE
Add 'auth_type' for phpMyAdminDatabase configuration

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "pj@ezgr.net"
 license          "Apache Public License 2.0"
 description      "Installs/Configures PHPMyAdmin"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.2"
+version          "1.0.3"
 
 depends "php"
 

--- a/providers/db.rb
+++ b/providers/db.rb
@@ -36,7 +36,8 @@ action :create do
 			:hide_dbs => new_resource.hide_dbs,
 			:pma_user => new_resource.pma_username,
 			:pma_pass => new_resource.pma_password,
-			:pma_db => new_resource.pma_database
+                        :pma_db => new_resource.pma_database,
+                        :auth_type => new_resource.auth_type,
 		})
 		mode 00644
 	end

--- a/resources/db.rb
+++ b/resources/db.rb
@@ -30,3 +30,4 @@ attribute :hide_dbs,		:kind_of => [ Array, String ], :default => []
 attribute :pma_username,	:kind_of => String, :default => ''
 attribute :pma_password,	:kind_of => String, :default => ''
 attribute :pma_database,	:kind_of => String, :default => ''
+attribute :auth_type,           :kind_of => String, :default => 'config'

--- a/templates/default/dbinstance.inc.php.erb
+++ b/templates/default/dbinstance.inc.php.erb
@@ -3,7 +3,7 @@
 $i++;
 
 /* Authentication type */
-$cfg['Servers'][$i]['auth_type'] = 'config';
+$cfg['Servers'][$i]['auth_type'] = '<%= @auth_type %>';
 /* Server parameters */
 $cfg['Servers'][$i]['host'] = '<%= @host %>';
 $cfg['Servers'][$i]['port'] = '<%= @port %>';


### PR DESCRIPTION
Patch in a an easy way to set the authentication type to 'cookie' or something else.
