### PR TITLE
Add option to install php with other cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['phpmyadmin']['mirror'] = 'http://downloads.sourceforge.net/project/phpm
 default['phpmyadmin']['server_name'] = node['fqdn']
 
 default['phpmyadmin']['fpm'] = true
+default['phpmyadmin']['stand_alone'] = true
 
 default['phpmyadmin']['home'] = '/opt/phpmyadmin'
 default['phpmyadmin']['user'] = 'phpmyadmin'
@@ -47,6 +48,6 @@ default['phpmyadmin']['default_lang'] = 'en'
 default['phpmyadmin']['default_display'] = 'horizontal'
 default['phpmyadmin']['query_history'] = true
 default['phpmyadmin']['query_history_size'] = 100
-	
+
 default['phpmyadmin']['config_template'] = 'config.inc.php.erb'
 default['phpmyadmin']['config_template_cookbook'] = 'phpmyadmin'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,11 +20,29 @@
 require 'digest/sha1'
 
 # PHP Recipe includes we already know PHPMyAdmin needs
-include_recipe 'php'
-include_recipe 'php::module_mbstring'
-include_recipe 'php::module_mcrypt'
-include_recipe 'php::module_gd'
-include_recipe 'php::module_mysql'
+if node['phpmyadmin']['stand_alone'] then
+	include_recipe 'php'
+	include_recipe 'php::module_mbstring'
+	include_recipe 'php::module_mcrypt'
+	include_recipe 'php::module_gd'
+	include_recipe 'php::module_mysql'
+
+	directory node['phpmyadmin']['upload_dir'] do
+		owner 'root'
+		group 'root'
+		mode 01777
+		recursive true
+		action :create
+	end
+
+	directory node['phpmyadmin']['save_dir'] do
+		owner 'root'
+		group 'root'
+		mode 01777
+		recursive true
+		action :create
+	end
+end
 
 home = node['phpmyadmin']['home']
 user = node['phpmyadmin']['user']
@@ -48,22 +66,6 @@ directory home do
 	owner user
 	group group
 	mode 00755
-	recursive true
-	action :create
-end
-
-directory node['phpmyadmin']['upload_dir'] do
-	owner 'root'
-	group 'root'
-	mode 01777
-	recursive true
-	action :create
-end
-
-directory node['phpmyadmin']['save_dir'] do
-	owner 'root'
-	group 'root'
-	mode 01777
 	recursive true
 	action :create
 end


### PR DESCRIPTION
This PR enables option to install and configure PHP outside of phpmyadmin cookbook.
By default, phpmyadmin can be installed in 1 server as stand alone service as attribute name suggests.