### PR TITLE
Change mirror URLs and version bump default package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ You can clone it and import it to Chef as
 	git clone git://github.com/priestjim/chef-phpmyadmin.git phpmyadmin
 	knife cookbook upload phpmyadmin
 
+You can also install the latest version of the cookbook using Berkshelf. Add
+the following to your Berksfile:
+
+    cookbook "phpmyadmin", github: "priestjim/chef-phpmyadmin"
+
 The latest and greatest revision of this cookbook will always be available
 at https://github.com/priestjim/chef-phpmyadmin
 
@@ -17,7 +22,7 @@ Requirements
 
 This cookbook requires the following cookbooks to be present and installed:
 
-* chef-php from https://github.com/priestjim/chef-php
+* [chef-php](https://github.com/priestjim/chef-php)
 
 It also suggests the following:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-default['phpmyadmin']['version'] = '4.3.1'
-default['phpmyadmin']['checksum'] = '944e42f33cb59b62bbc56165ea785216667198b98d254dff1265ba5793b8268e'
-default['phpmyadmin']['mirror'] = 'http://downloads.sourceforge.net/project/phpmyadmin/phpMyAdmin'
+default['phpmyadmin']['version'] = '4.3.13.1'
+default['phpmyadmin']['checksum'] = '2e5c2ca358d9510c793bb709338f0836c56f4c151018ad36a74da1d32df9fcd3'
+default['phpmyadmin']['mirror'] = 'https://files.phpmyadmin.net/phpMyAdmin/'
 default['phpmyadmin']['server_name'] = node['fqdn']
 
 default['phpmyadmin']['fpm'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -30,7 +30,7 @@ attribute 'phpmyadmin/checksum',
 attribute 'phpmyadmin/mirror',
   :display_name => 'PHPMyAdmin download mirror',
   :description => 'The desired PMA download mirror',
-  :default => 'http://netcologne.dl.sourceforge.net/project/phpmyadmin/phpMyAdmin'
+  :default => 'https://files.phpmyadmin.net/phpMyAdmin/'
 
 attribute 'phpmyadmin/fpm',
   :display_name => 'PHPMyAdmin FPM instance',


### PR DESCRIPTION
Today, phpMyAdmin maintainers [announced](https://www.phpmyadmin.net/news/2015/7/2/phpmyadmin-website-and-downloads-moved/) that they moved phpMyAdmin website and downloads from SourceForge to a new CDN. 

I updated attributes to show to the new mirrors, version bumped phpMyAdmin to the [latest](https://www.phpmyadmin.net/files/4.3.13.1/) version of 4.3.* and added some small improvements in README.

Thanks,
Pavlos