### PR TITLE
Add not_if guard to fix error when user already exists

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,7 @@ user user do
 	home home
 	shell '/usr/sbin/nologin'
 	supports :manage_home => true
+	not_if "grep #{user} /etc/passwd"
 end
 
 directory home do


### PR DESCRIPTION
I got following error when I used existing user to install phpmyadmin so added not_if guard.

```
 Recipe: phpmyadmin::default
         * group[wwww-data] action create (up to date)
         * group[wwww-data] action manage (up to date)
         * user[www-data] action create
           ================================================================================
           Error executing action `create` on resource 'user[www-data]'
           ================================================================================
           
           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '8'
           ---- Begin output of ["usermod", "-c", "PHPMyAdmin User", "-g", "1001", "-d", "/websites/phpmyadmin", "-m", "www-data"] ----
           STDOUT: 
       STDERR: usermod: user www-data is currently used by process 27741
           ---- End output of ["usermod", "-c", "PHPMyAdmin User", "-g", "1001", "-d", "/websites/phpmyadmin", "-m", "www-data"] ----
           Ran ["usermod", "-c", "PHPMyAdmin User", "-g", "1001", "-d", "/websites/phpmyadmin", "-m", "www-data"] returned 8
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/phpmyadmin/recipes/default.rb
           
        56: user user do
            57:         action [ :create, :manage ]
            58:         comment 'PHPMyAdmin User'
            59:         gid group
            60:         home home
            61:         shell '/usr/sbin/nologin'
            62:         supports :manage_home => true
            63: end
            64: 
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/phpmyadmin/recipes/default.rb:56:in `from_file'
           
           user("www-data") do
             action [:create, :manage]
             supports {:manage_home=>true}
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             username "www-data"
             comment "PHPMyAdmin User"
             gid 1001
             home "/websites/phpmyadmin"
             shell "/usr/sbin/nologin"
             iterations 27855
             declared_type :user
             cookbook_name "phpmyadmin"
             recipe_name "default"
           end
```